### PR TITLE
[Bug] 修复接口generate-chapter-stream 的参数project_overview为空的问题

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -170,5 +170,4 @@ class WordExportRequest(BaseModel):
     """Word导出请求"""
 
     project_name: Optional[str] = Field(None, description="项目名称")
-    project_overview: Optional[str] = Field(None, description="项目概述")
     outline: List[WordExportOutlineItem] = Field(..., description="目录结构，包含内容")

--- a/backend/app/services/word_export_service.py
+++ b/backend/app/services/word_export_service.py
@@ -31,9 +31,7 @@ class WordExportService:
     def export_outline(request: WordExportRequest) -> tuple[io.BytesIO, dict[str, str]]:
         doc = docx.Document()
         WordExportService._init_document_styles(doc)
-        WordExportService._add_document_intro(
-            doc, request.project_name, request.project_overview
-        )
+        WordExportService._add_document_intro(doc, request.project_name)
         WordExportService._add_outline_items(doc, request.outline)
 
         buffer = io.BytesIO()
@@ -67,7 +65,7 @@ class WordExportService:
 
     @staticmethod
     def _add_document_intro(
-        doc: docx.Document, project_name: str | None, project_overview: str | None
+        doc: docx.Document, project_name: str | None
     ) -> None:
         declaration = doc.add_paragraph()
         declaration_run = declaration.add_run("内容由AI生成")
@@ -83,13 +81,6 @@ class WordExportService:
         _set_run_font_simsun(title_run)
         title_paragraph.alignment = WD_ALIGN_PARAGRAPH.CENTER
 
-        if project_overview:
-            heading = doc.add_heading("项目概述", level=1)
-            heading.alignment = WD_ALIGN_PARAGRAPH.LEFT
-            _set_paragraph_font_simsun(heading)
-            overview_paragraph = doc.add_paragraph(project_overview)
-            _set_paragraph_font_simsun(overview_paragraph)
-            overview_paragraph.paragraph_format.space_after = Pt(12)
 
     @staticmethod
     def _add_markdown_runs(para: docx.text.paragraph.Paragraph, text: str) -> None:

--- a/frontend/src/pages/ContentEdit.tsx
+++ b/frontend/src/pages/ContentEdit.tsx
@@ -350,7 +350,6 @@ const ContentEdit: React.FC<ContentEditProps> = ({
 
       const exportPayload = {
         project_name: outlineData.project_name,
-        project_overview: outlineData.project_overview,
         outline: buildExportOutline(outlineData.outline),
       };
 

--- a/frontend/src/pages/OutlineEdit.tsx
+++ b/frontend/src/pages/OutlineEdit.tsx
@@ -101,7 +101,10 @@ const OutlineEdit: React.FC<OutlineEditProps> = ({
         throw new Error('未收到目录生成结果');
       }
 
-      const finalOutline = outlineResult as OutlineData;
+      const finalOutline: OutlineData = {
+        outline: (outlineResult as OutlineData).outline ?? (outlineResult as unknown as OutlineItem[]),
+        project_overview: projectOverview,
+      };
 
       onOutlineGenerated(finalOutline);
       setMessage({ type: 'success', text: '目录结构生成完成' });

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -46,7 +46,6 @@ export interface ChapterContentRequest {
 
 export interface WordExportRequest {
   project_name?: string;
-  project_overview?: string;
   outline: OutlineItem[];
 }
 


### PR DESCRIPTION
使用`/api/content/generate-chapter-stream`接口时，发现其中的参数`project_overview`总是为空，使得后端生成标书内容时只能参考目录和条目而不能参考项目的概要，于是进行了以下操作：

## 概要：
1. 修复前端接口`/api/content/generate-chapter-stream`的传参使得`project_overview`不为空。
2. 请求移除了 Word 导出功能中对`project_overview`字段的支持，涉及后端和前端。这些改动确保项目概览不再包含在导出请求、文档生成或 API 接口中。
3. 原本后端生成的标书会带未经渲染的md格式的项目概要，为保持和原本输出的格式一致因此将其删除。

## 修改细节

**后端改动：**

* 从`schemas.py`文件的`WordExportRequest`模型中移除了`project_overview`字段，以简化数据模型。
* 更新了`WordExportService`方法，移除了所有与处理和插入项目概览到导出文档相关的逻辑。这包括从`_add_document_intro`中移除该参数，并删除了添加概览内容的部分。[[1]](diffhunk://#diff-064a564e7ea69f2c8e763d14f982029d33569c6eb28f81540af96ecd59a8053aL34-R34) [[2]](diffhunk://#diff-064a564e7ea69f2c8e763d14f982029d33569c6eb28f81540af96ecd59a8053aL70-R68) [[3]](diffhunk://#diff-064a564e7ea69f2c8e763d14f982029d33569c6eb28f81540af96ecd59a8053aL86-L92)

**前端变更：**

* 从 `WordExportRequest` 接口以及导出请求发送的有效载荷中移除了 `project_overview`，确保与后端变更保持一致。[[1]](diffhunk://#diff-6b9e3d4b74a21021633aafa3210a7682cf737f80bd4c35c2ac622d1a983a7c64L49) [[2]](diffhunk://#diff-d7a4e6b5311cacfb2ba79e20a962ccd3513d0c844ed311f187eb0db69586e505L353)
* 更新了 `OutlineEdit.tsx` 中的大纲生成逻辑，继续在本地大纲数据中包含 `project_overview`，但该字段不再作为导出的一部分发送到后端。