### PR TITLE
fix: build macOS releases on matching architectures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,14 +58,10 @@ jobs:
             gh release create "$TAG_NAME" --title "$TAG_NAME" --notes-file release_notes.md
           fi
 
-  build:
-    name: Build ${{ matrix.os }}
+  build-windows:
+    name: Build Windows
     needs: create-release
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows-latest, macos-latest]
+    runs-on: windows-latest
 
     defaults:
       run:
@@ -85,16 +81,95 @@ jobs:
           cache: npm
           cache-dependency-path: client/package-lock.json
 
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install build type dependencies
+        run: npm install --no-save @types/plist
+
+      - name: Rebuild Electron native dependencies
+        run: npm run postinstall
+
+      - name: Smoke test Electron native dependencies
+        run: npm run smoke:electron-native
+
+      - name: Sync package version from tag
+        env:
+          TAG_NAME: ${{ inputs.tag_name || github.ref_name }}
+        run: |
+          VERSION="${TAG_NAME#v}"
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
+
+      - name: Build renderer
+        run: npm run build
+
+      - name: Build Windows NSIS and ZIP artifacts
+        run: npx electron-builder --win nsis zip --publish never
+
+      - name: Build Windows MSI artifact
+        run: npx electron-builder --win msi --publish never -c.productName=OpenBidKit_Yibiao -c.extraMetadata.author=mark -c.copyright="Copyright (c) 2026 mark"
+
+      - name: Upload release assets
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ inputs.tag_name || github.ref_name }}
+        run: |
+          shopt -s nullglob
+          files=(release/*.exe release/*.msi release/*.zip release/*.blockmap release/latest*.yml)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No release assets found."
+            exit 1
+          fi
+          gh release upload "$TAG_NAME" "${files[@]}" --clobber
+
+  build-macos:
+    name: Build macOS ${{ matrix.arch }}
+    needs: create-release
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-15-intel
+            arch: x64
+          - runner: macos-15
+            arch: arm64
+
+    defaults:
+      run:
+        working-directory: client
+        shell: bash
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag_name || github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: client/package-lock.json
+
+      - name: Verify runner architecture
+        run: |
+          actual_arch="$(node -p process.arch)"
+          if [ "$actual_arch" != "${{ matrix.arch }}" ]; then
+            echo "Expected ${{ matrix.arch }} runner, got ${actual_arch}."
+            exit 1
+          fi
+
       - name: Cache Electron build downloads
-        if: runner.os == 'macOS'
         uses: actions/cache@v4
         with:
           path: |
             ~/Library/Caches/electron
             ~/Library/Caches/electron-builder
-          key: ${{ runner.os }}-electron-${{ hashFiles('client/package-lock.json') }}
+          key: ${{ runner.os }}-${{ matrix.arch }}-electron-${{ hashFiles('client/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-electron-
+            ${{ runner.os }}-${{ matrix.arch }}-electron-
 
       - name: Install dependencies
         run: npm ci
@@ -116,7 +191,6 @@ jobs:
           npm version "$VERSION" --no-git-tag-version --allow-same-version
 
       - name: Generate macOS icon
-        if: runner.os == 'macOS'
         run: |
           rm -rf assets/icon.iconset
           mkdir -p assets/icon.iconset
@@ -135,47 +209,34 @@ jobs:
       - name: Build renderer
         run: npm run build
 
-      - name: Preload Electron macOS runtimes
-        if: runner.os == 'macOS'
+      - name: Preload Electron macOS runtime
         run: |
           export ELECTRON_CACHE="$HOME/Library/Caches/electron"
           ELECTRON_VERSION="$(node -p "require('./node_modules/electron/package.json').version")"
-          cache_dir="$ELECTRON_CACHE"
-          mkdir -p "$cache_dir"
+          file="$ELECTRON_CACHE/electron-v${ELECTRON_VERSION}-darwin-${{ matrix.arch }}.zip"
+          mkdir -p "$ELECTRON_CACHE"
 
-          for arch in x64 arm64; do
-            file="$cache_dir/electron-v${ELECTRON_VERSION}-darwin-${arch}.zip"
-            if [ -f "$file" ] && unzip -tq "$file" >/dev/null 2>&1; then
-              echo "Electron ${ELECTRON_VERSION} darwin-${arch} already cached."
-              continue
-            fi
+          if [ -f "$file" ] && unzip -tq "$file" >/dev/null 2>&1; then
+            echo "Electron ${ELECTRON_VERSION} darwin-${{ matrix.arch }} already cached."
+            exit 0
+          fi
 
-            tmp="${file}.tmp"
-            rm -f "$file" "$tmp"
-            curl --fail --location --retry 5 --retry-all-errors --retry-delay 10 \
-              "https://github.com/electron/electron/releases/download/v${ELECTRON_VERSION}/electron-v${ELECTRON_VERSION}-darwin-${arch}.zip" \
-              --output "$tmp"
-            unzip -tq "$tmp" >/dev/null
-            mv "$tmp" "$file"
-          done
+          tmp="${file}.tmp"
+          rm -f "$file" "$tmp"
+          curl --fail --location --retry 5 --retry-all-errors --retry-delay 10 \
+            "https://github.com/electron/electron/releases/download/v${ELECTRON_VERSION}/electron-v${ELECTRON_VERSION}-darwin-${{ matrix.arch }}.zip" \
+            --output "$tmp"
+          unzip -tq "$tmp" >/dev/null
+          mv "$tmp" "$file"
 
-      - name: Build Windows NSIS and ZIP artifacts
-        if: runner.os == 'Windows'
-        run: npx electron-builder --win nsis zip --publish never
-
-      - name: Build Windows MSI artifact
-        if: runner.os == 'Windows'
-        run: npx electron-builder --win msi --publish never -c.productName=OpenBidKit_Yibiao -c.extraMetadata.author=mark -c.copyright="Copyright (c) 2026 mark"
-
-      - name: Build and publish macOS artifacts
-        if: runner.os == 'macOS'
+      - name: Build macOS artifacts
         run: |
           export ELECTRON_CACHE="$HOME/Library/Caches/electron"
           export ELECTRON_BUILDER_CACHE="$HOME/Library/Caches/electron-builder"
 
           for attempt in 1 2 3; do
-            echo "Build macOS artifacts, attempt ${attempt}/3."
-            if npx electron-builder --mac --publish never; then
+            echo "Build macOS ${{ matrix.arch }} artifacts, attempt ${attempt}/3."
+            if npx electron-builder --mac --${{ matrix.arch }} --publish never; then
               exit 0
             fi
 
@@ -186,11 +247,19 @@ jobs:
             sleep $((attempt * 20))
           done
 
+      - name: Verify packaged native architectures
+        run: node scripts/verify-macos-native-arch.cjs "${{ matrix.arch }}" release
+
       - name: Package macOS DMG with instructions
-        if: runner.os == 'macOS'
         run: |
           shopt -s nullglob
-          for dmg in release/*.dmg; do
+          dmgs=(release/*.dmg)
+          if [ ${#dmgs[@]} -ne 1 ]; then
+            echo "Expected exactly one macOS ${{ matrix.arch }} DMG, found ${#dmgs[@]}."
+            exit 1
+          fi
+
+          for dmg in "${dmgs[@]}"; do
             base="$(basename "$dmg" .dmg)"
             package_dir="release/${base}-package"
             rm -rf "$package_dir"
@@ -219,15 +288,74 @@ jobs:
             rm -f "$dmg"
           done
 
-      - name: Upload release assets
+      - name: Stage macOS release assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-${{ matrix.arch }}
+          path: |
+            client/release/*.zip
+            client/release/*.blockmap
+            client/release/latest-mac.yml
+          if-no-files-found: error
+
+  publish-macos:
+    name: Publish macOS
+    needs:
+      - create-release
+      - build-macos
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag_name || github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: client/package-lock.json
+
+      - name: Install manifest tooling
+        working-directory: client
+        run: npm ci --ignore-scripts --omit=optional
+
+      - name: Download macOS x64 artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-x64
+          path: artifacts/x64
+
+      - name: Download macOS arm64 artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-arm64
+          path: artifacts/arm64
+
+      - name: Merge macOS update manifests
+        run: |
+          node client/scripts/merge-mac-update-manifests.cjs \
+            artifacts/x64/latest-mac.yml \
+            artifacts/arm64/latest-mac.yml \
+            artifacts/latest-mac.yml
+
+      - name: Upload macOS release assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ inputs.tag_name || github.ref_name }}
         run: |
           shopt -s nullglob
-          files=(release/*.exe release/*.msi release/*.zip release/*.blockmap release/latest*.yml)
-          if [ ${#files[@]} -eq 0 ]; then
-            echo "No release assets found."
+          files=(
+            artifacts/x64/*.zip
+            artifacts/x64/*.blockmap
+            artifacts/arm64/*.zip
+            artifacts/arm64/*.blockmap
+            artifacts/latest-mac.yml
+          )
+          if [ ${#files[@]} -ne 5 ]; then
+            echo "Expected five macOS release assets, found ${#files[@]}."
             exit 1
           fi
           gh release upload "$TAG_NAME" "${files[@]}" --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -347,6 +347,22 @@ jobs:
           TAG_NAME: ${{ inputs.tag_name || github.ref_name }}
         run: |
           shopt -s nullglob
+
+          require_single_asset() {
+            local label="$1"
+            shift
+            if [ "$#" -ne 1 ]; then
+              echo "Expected exactly one ${label}, found $#."
+              exit 1
+            fi
+          }
+
+          require_single_asset "macOS x64 package ZIP" artifacts/x64/*-package.zip
+          require_single_asset "macOS x64 DMG blockmap" artifacts/x64/*.dmg.blockmap
+          require_single_asset "macOS arm64 package ZIP" artifacts/arm64/*-package.zip
+          require_single_asset "macOS arm64 DMG blockmap" artifacts/arm64/*.dmg.blockmap
+          require_single_asset "merged macOS update manifest" artifacts/latest-mac.yml
+
           files=(
             artifacts/x64/*.zip
             artifacts/x64/*.blockmap
@@ -354,8 +370,4 @@ jobs:
             artifacts/arm64/*.blockmap
             artifacts/latest-mac.yml
           )
-          if [ ${#files[@]} -ne 5 ]; then
-            echo "Expected five macOS release assets, found ${#files[@]}."
-            exit 1
-          fi
           gh release upload "$TAG_NAME" "${files[@]}" --clobber

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -49,6 +49,7 @@
         "cross-env": "^10.0.0",
         "electron": "^41.5.0",
         "electron-builder": "^26.8.1",
+        "js-yaml": "^4.1.1",
         "typescript": "^5.9.2",
         "vite": "^7.1.7",
         "wait-on": "^8.0.4"

--- a/client/package.json
+++ b/client/package.json
@@ -124,6 +124,7 @@
     "cross-env": "^10.0.0",
     "electron": "^41.5.0",
     "electron-builder": "^26.8.1",
+    "js-yaml": "^4.1.1",
     "typescript": "^5.9.2",
     "vite": "^7.1.7",
     "wait-on": "^8.0.4"

--- a/client/scripts/merge-mac-update-manifests.cjs
+++ b/client/scripts/merge-mac-update-manifests.cjs
@@ -1,0 +1,76 @@
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const [, , x64ManifestPath, arm64ManifestPath, outputPath] = process.argv;
+
+if (!x64ManifestPath || !arm64ManifestPath || !outputPath) {
+  console.error(
+    'Usage: node scripts/merge-mac-update-manifests.cjs <x64-yml> <arm64-yml> <output-yml>',
+  );
+  process.exit(2);
+}
+
+function readManifest(manifestPath) {
+  const absolutePath = path.resolve(manifestPath);
+  const manifest = yaml.load(fs.readFileSync(absolutePath, 'utf8'), {
+    schema: yaml.JSON_SCHEMA,
+  });
+  if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) {
+    throw new Error(`Invalid update manifest: ${absolutePath}`);
+  }
+  if (!manifest.version || !Array.isArray(manifest.files) || manifest.files.length === 0) {
+    throw new Error(`Update manifest is missing version or files: ${absolutePath}`);
+  }
+  return manifest;
+}
+
+const manifests = [readManifest(x64ManifestPath), readManifest(arm64ManifestPath)];
+const versions = new Set(manifests.map((manifest) => manifest.version));
+if (versions.size !== 1) {
+  throw new Error(`Cannot merge manifests with different versions: ${[...versions].join(', ')}`);
+}
+
+const filesByUrl = new Map();
+for (const manifest of manifests) {
+  for (const file of manifest.files) {
+    if (!file?.url || !file?.sha512) {
+      throw new Error(`Manifest ${manifest.version} contains an invalid file entry.`);
+    }
+    const existing = filesByUrl.get(file.url);
+    if (existing && JSON.stringify(existing) !== JSON.stringify(file)) {
+      throw new Error(`Conflicting metadata for ${file.url}`);
+    }
+    filesByUrl.set(file.url, file);
+  }
+}
+
+const primary = manifests.find((manifest) => String(manifest.path).includes('x64')) || manifests[0];
+const releaseDates = manifests
+  .map((manifest) => manifest.releaseDate)
+  .filter(Boolean)
+  .sort();
+
+const merged = {
+  ...primary,
+  files: [...filesByUrl.values()],
+};
+if (releaseDates.length > 0) {
+  merged.releaseDate = releaseDates.at(-1);
+}
+
+fs.mkdirSync(path.dirname(path.resolve(outputPath)), { recursive: true });
+fs.writeFileSync(
+  path.resolve(outputPath),
+  yaml.dump(merged, {
+    schema: yaml.JSON_SCHEMA,
+    forceQuotes: true,
+    lineWidth: -1,
+    noRefs: true,
+    quotingType: "'",
+  }),
+);
+
+console.log(
+  `[update-manifest] merged ${merged.files.length} files for version ${merged.version} into ${path.resolve(outputPath)}.`,
+);

--- a/client/scripts/verify-macos-native-arch.cjs
+++ b/client/scripts/verify-macos-native-arch.cjs
@@ -1,0 +1,88 @@
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const [, , requestedArch, releaseDirectory = 'release'] = process.argv;
+const lipoArch = {
+  x64: 'x86_64',
+  arm64: 'arm64',
+}[requestedArch];
+
+if (!lipoArch) {
+  console.error('Usage: node scripts/verify-macos-native-arch.cjs <x64|arm64> [release-directory]');
+  process.exit(2);
+}
+
+const releaseRoot = path.resolve(releaseDirectory);
+
+function collectTopLevelApps(directory, apps = []) {
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const entryPath = path.join(directory, entry.name);
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    if (entry.name.endsWith('.app')) {
+      apps.push(entryPath);
+      continue;
+    }
+    collectTopLevelApps(entryPath, apps);
+  }
+  return apps;
+}
+
+function collectNativeBinaries(directory, binaries = []) {
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isSymbolicLink()) {
+      continue;
+    }
+    if (entry.isDirectory()) {
+      collectNativeBinaries(entryPath, binaries);
+      continue;
+    }
+
+    const normalizedPath = entryPath.split(path.sep).join('/');
+    if (entry.name.endsWith('.node') || normalizedPath.includes('/Contents/MacOS/')) {
+      binaries.push(entryPath);
+    }
+  }
+  return binaries;
+}
+
+function verifyArchitecture(binaryPath) {
+  const result = spawnSync('lipo', [binaryPath, '-verify_arch', lipoArch], {
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) {
+    const details = [result.stdout, result.stderr].filter(Boolean).join('\n').trim();
+    throw new Error(`${binaryPath} does not contain ${lipoArch}${details ? `\n${details}` : ''}`);
+  }
+}
+
+if (!fs.existsSync(releaseRoot)) {
+  throw new Error(`Release directory does not exist: ${releaseRoot}`);
+}
+
+const apps = collectTopLevelApps(releaseRoot);
+if (apps.length === 0) {
+  throw new Error(`No .app bundle found under ${releaseRoot}`);
+}
+
+const binaries = apps.flatMap((appPath) => collectNativeBinaries(appPath));
+const nativeModules = binaries.filter((binaryPath) => binaryPath.endsWith('.node'));
+const executables = binaries.filter((binaryPath) => !binaryPath.endsWith('.node'));
+
+if (nativeModules.length === 0) {
+  throw new Error('No native Node modules were found in the packaged app.');
+}
+if (executables.length === 0) {
+  throw new Error('No app executables were found in the packaged app.');
+}
+
+for (const binaryPath of binaries) {
+  verifyArchitecture(binaryPath);
+}
+
+console.log(
+  `[native-arch] verified ${executables.length} executables and ${nativeModules.length} native modules contain ${lipoArch}.`,
+);


### PR DESCRIPTION
## 问题

当前发布工作流在同一台 Apple Silicon runner 上安装依赖后，同时交叉构建 x64 和 arm64。这样会把 arm64 的 `@napi-rs/canvas` 原生模块打入 x64 App，导致 Intel Mac 启动时报 `dlopen` 架构不兼容。

Closes #64

## 修改

- x64 改由 `macos-15-intel` 原生构建，arm64 改由 `macos-15` 原生构建。
- 构建后使用 `lipo` 检查 App 主程序及所有 `.node` 模块是否包含目标架构，发现混合架构时直接阻止发布。
- 两个 macOS 作业先上传 Actions artifacts，再合并各自的 `latest-mac.yml` 后统一发布，保留双架构自动更新元数据。
- Windows 构建和发布行为保持不变。

## 验证

- `actionlint .github/workflows/release.yml`
- `npm ci --dry-run --ignore-scripts --omit=optional`
- x86_64 Mach-O 测试样本通过架构校验
- 混入 arm64 Canvas 模块后校验按预期失败
- x64/arm64 示例更新清单成功合并并保留两条文件记录