### PR TITLE
fix: 标段检测器多项增强 — 支持4种标段格式

### DIFF
--- a/client/electron/utils/bidSectionDetector.cjs
+++ b/client/electron/utils/bidSectionDetector.cjs
@@ -4,60 +4,108 @@
  * 只返回检测到的标段列表，不做切分，下游根据用户选择的标段注入 AI 上下文。
  */
 
-const chineseNumMap = {
+const chineseDigits = ['零', '一', '二', '三', '四', '五', '六', '七', '八', '九', '十'];
+
+function chineseToDigit(ch) {
+  const idx = chineseDigits.indexOf(ch);
+  return idx >= 1 ? idx : null;
+}
+
+const chineseSmallMap = {
   '一': 1, '二': 2, '三': 3, '四': 4, '五': 5,
   '六': 6, '七': 7, '八': 8, '九': 9, '十': 10,
   '壹': 1, '贰': 2, '叁': 3, '肆': 4, '伍': 5,
 };
 
-const arabicToChinese = ['零', '一', '二', '三', '四', '五', '六', '七', '八', '九', '十'];
-
 function normalizeChineseNumber(value) {
   const trimmed = String(value || '').trim();
-  if (chineseNumMap[trimmed] !== undefined) {
-    return chineseNumMap[trimmed];
-  }
+  if (!trimmed) return null;
+  // Arabic digit
   const digit = Number(trimmed);
-  if (Number.isFinite(digit) && digit >= 1 && digit <= 20) {
+  if (Number.isFinite(digit) && digit >= 1 && digit <= 99) {
     return Math.floor(digit);
+  }
+  // Single Chinese digit (一～十 / 壹～伍)
+  if (chineseSmallMap[trimmed] !== undefined) {
+    return chineseSmallMap[trimmed];
+  }
+  // Compound: 十一～十九
+  if (trimmed.length === 2 && trimmed[0] === '十') {
+    const ones = chineseToDigit(trimmed[1]);
+    if (ones !== null) return 10 + ones;
+    return 10; // 十 alone maps to 10
+  }
+  // 二十～九十九
+  if (trimmed.length === 3 && trimmed[1] === '十') {
+    const tens = chineseToDigit(trimmed[0]);
+    const ones = chineseToDigit(trimmed[2]);
+    if (tens !== null && ones !== null) return tens * 10 + ones;
+  }
+  // 二十 (2-char form without ones digit)
+  if (trimmed.length === 2 && trimmed[1] === '十') {
+    const tens = chineseToDigit(trimmed[0]);
+    if (tens !== null) return tens * 10;
   }
   return null;
 }
 
 function formatChineseNumber(value) {
-  return arabicToChinese[value] || String(value);
+  const num = Number(value);
+  if (!Number.isFinite(num) || num < 1) return String(value);
+  if (num <= 10) return chineseDigits[num];
+  if (num < 20) return `十${chineseDigits[num - 10]}`;
+  if (num <= 99) {
+    const tens = Math.floor(num / 10);
+    const ones = num % 10;
+    const tensStr = chineseDigits[tens];
+    const onesStr = ones > 0 ? chineseDigits[ones] : '';
+    return `${tensStr}十${onesStr}`;
+  }
+  return String(num); // fallback for >= 100 (extremely unlikely for 标段)
 }
 
-const totalSectionPattern = /(?:本?项目)?(?:共|总计|共计|合计)?(?:划分|分|设|拆|分拆)为?\s*(\d+|[一二三四五六七八九十]+)\s*个?\s*(?:标段|包|分包|标包|子项目)/g;
+const totalSectionPattern = /(?:本?项目)?(?:共|总计|共计|合计)?(?:划分|分|设|拆|分拆)?为?\s*(\d+|[一二三四五六七八九十]+)\s*个?\s*(?:标段|包|分包|标包|标的|子项目)/g;
 
 function detectTotalSectionCount(markdown) {
-  const matches = [...String(markdown || '').matchAll(totalSectionPattern)];
+  const text = String(markdown || '');
+  const matches = [...text.matchAll(totalSectionPattern)];
+  if (!matches.length) return null;
+
+  // Collect all valid counts, noting whether each refers to 标段 specifically
+  let sectionCount = null;
+  let anyCount = null;
   for (const match of matches) {
     const count = normalizeChineseNumber(match[1]);
     if (count && count >= 2) {
-      return count;
+      anyCount = anyCount === null ? count : Math.max(anyCount, count);
+      // Prefer counts from matches that explicitly say 标段 (not 标的/包/etc.)
+      const fullMatch = match[0];
+      if (/标段/.test(fullMatch)) {
+        sectionCount = sectionCount === null ? count : Math.max(sectionCount, count);
+      }
     }
   }
-  return null;
+  // Return 标段 count first, then fall back to any valid count
+  return sectionCount ?? anyCount;
 }
 
 const sectionDefinitionPatterns = [
-  { pattern: /([一二三四五六七八九十壹贰叁肆伍]+)标段[：:]/g, unit: '标段' },
-  { pattern: /(\d+)标段[：:]/g, unit: '标段' },
-  { pattern: /第([一二三四五六七八九十壹贰叁肆伍\d]+)标段[：:]/g, unit: '标段' },
-  { pattern: /标段([一二三四五六七八九十壹贰叁肆伍\d]+)[：:]/g, unit: '标段' },
-  { pattern: /([一二三四五六七八九十壹贰叁肆伍]+)标包[：:]/g, unit: '标包' },
-  { pattern: /(\d+)标包[：:]/g, unit: '标包' },
-  { pattern: /第([一二三四五六七八九十壹贰叁肆伍\d]+)标包[：:]/g, unit: '标包' },
-  { pattern: /标包([一二三四五六七八九十壹贰叁肆伍\d]+)[：:]/g, unit: '标包' },
-  { pattern: /([一二三四五六七八九十壹贰叁肆伍]+)分包[：:]/g, unit: '分包' },
-  { pattern: /(\d+)分包[：:]/g, unit: '分包' },
-  { pattern: /第([一二三四五六七八九十壹贰叁肆伍\d]+)分包[：:]/g, unit: '分包' },
-  { pattern: /分包([一二三四五六七八九十壹贰叁肆伍\d]+)[：:]/g, unit: '分包' },
-  { pattern: /([一二三四五六七八九十壹贰叁肆伍]+)包[：:]/g, unit: '包' },
-  { pattern: /(\d+)包[：:]/g, unit: '包' },
-  { pattern: /第([一二三四五六七八九十壹贰叁肆伍\d]+)包[：:]/g, unit: '包' },
-  { pattern: /包([一二三四五六七八九十壹贰叁肆伍\d]+)[：:]/g, unit: '包' },
+  { pattern: /([一二三四五六七八九十壹贰叁肆伍]+)标段[：:；;]/g, unit: '标段' },
+  { pattern: /(\d+)标段[：:；;]/g, unit: '标段' },
+  { pattern: /第([一二三四五六七八九十壹贰叁肆伍\d]+)标段[：:；;]/g, unit: '标段' },
+  { pattern: /标段([一二三四五六七八九十壹贰叁肆伍\d]+)[：:；;]/g, unit: '标段' },
+  { pattern: /([一二三四五六七八九十壹贰叁肆伍]+)标包[：:；;]/g, unit: '标包' },
+  { pattern: /(\d+)标包[：:；;]/g, unit: '标包' },
+  { pattern: /第([一二三四五六七八九十壹贰叁肆伍\d]+)标包[：:；;]/g, unit: '标包' },
+  { pattern: /标包([一二三四五六七八九十壹贰叁肆伍\d]+)[：:；;]/g, unit: '标包' },
+  { pattern: /([一二三四五六七八九十壹贰叁肆伍]+)分包[：:；;]/g, unit: '分包' },
+  { pattern: /(\d+)分包[：:；;]/g, unit: '分包' },
+  { pattern: /第([一二三四五六七八九十壹贰叁肆伍\d]+)分包[：:；;]/g, unit: '分包' },
+  { pattern: /分包([一二三四五六七八九十壹贰叁肆伍\d]+)[：:；;]/g, unit: '分包' },
+  { pattern: /([一二三四五六七八九十壹贰叁肆伍]+)包[：:；;]/g, unit: '包' },
+  { pattern: /(\d+)包[：:；;]/g, unit: '包' },
+  { pattern: /第([一二三四五六七八九十壹贰叁肆伍\d]+)包[：:；;]/g, unit: '包' },
+  { pattern: /包([一二三四五六七八九十壹贰叁肆伍\d]+)[：:；;]/g, unit: '包' },
 ];
 
 function getSectionUnit(title) {
@@ -65,8 +113,18 @@ function getSectionUnit(title) {
   return match?.[1] || '标段';
 }
 
+function stripHtml(text) {
+  return String(text || '')
+    .replace(/<br\s*\/?>/gi, ' ')
+    .replace(/<[^>]+>/g, '')
+    .replace(/<[^>]*$/g, '')    // partial tag at truncation boundary
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
 function stripSectionPrefix(headLine) {
-  return String(headLine || '').replace(/^.*?(?:标段|标包|分包|包)[：:]\s*/, '');
+  return stripHtml(String(headLine || ''))
+    .replace(/^.*?(?:标段|标包|分包|包)[：:；;]\s*/, '');
 }
 
 function extractLineContext(markdown, matchIndex, maxLength = 240) {
@@ -79,13 +137,24 @@ function extractLineContext(markdown, matchIndex, maxLength = 240) {
   while (lineEnd < text.length && text[lineEnd] !== '\n') {
     lineEnd += 1;
   }
-  const headLine = text.slice(lineStart, lineEnd).trim();
+  const rawHeadLine = text.slice(lineStart, lineEnd).trim();
+  // Extract description: up to 3 extra lines, but stop before next section header
+  const nextSectionPattern = /(?:\d{3}\s+)?(?:第[一二三四五六七八九十\d]+|[一二三四五六七八九十]+)\s*(?:标段|标包|分包|包)[：:；;]/g;
   let descriptionEnd = lineEnd;
   let extraLines = 0;
   while (descriptionEnd < text.length && extraLines < 3) {
     const nextBreak = text.indexOf('\n', descriptionEnd + 1);
+    const chunkEnd = nextBreak === -1 ? Math.min(text.length, descriptionEnd + maxLength) : nextBreak;
+    // Check for next section header within the upcoming chunk
+    const ahead = text.slice(descriptionEnd, Math.min(descriptionEnd + maxLength, text.length));
+    nextSectionPattern.lastIndex = 0;
+    const nextMatch = nextSectionPattern.exec(ahead);
+    if (nextMatch && nextMatch.index > 0) {
+      descriptionEnd = descriptionEnd + nextMatch.index;
+      break;
+    }
     if (nextBreak === -1) {
-      descriptionEnd = text.length;
+      descriptionEnd = Math.min(text.length, descriptionEnd + maxLength);
       break;
     }
     descriptionEnd = nextBreak;
@@ -94,9 +163,9 @@ function extractLineContext(markdown, matchIndex, maxLength = 240) {
       break;
     }
   }
-  const description = text.slice(lineStart, Math.min(descriptionEnd, lineStart + maxLength))
-    .replace(/\s+/g, ' ')
-    .trim();
+  const rawDescription = text.slice(lineStart, Math.min(descriptionEnd, lineStart + maxLength));
+  const headLine = stripHtml(rawHeadLine);
+  const description = stripHtml(rawDescription);
   return { headLine, description };
 }
 
@@ -121,6 +190,71 @@ function dedupeSections(sections) {
   return result.sort((a, b) => a.index - b.index);
 }
 
+// 【X-Y】/【X】 bracket patterns, common in 南方电网 / 国家电网 bidding documents.
+// Only matches at line start to avoid false positives from in-text document numbers.
+const bracketPattern = /^【(\d+)(?:-(\d+))?】/gm;
+
+function isDocumentNumberLine(headLine) {
+  // Skip lines that look like government document numbers: 【2021】7号文, etc.
+  return /[号文]$|^\s*【\d+】\d+\s*号/.test(headLine) || /号文/.test(headLine);
+}
+
+function detectBracketSections(markdown) {
+  const text = String(markdown || '');
+  bracketPattern.lastIndex = 0;
+
+  const raw = [];
+  let match;
+  while ((match = bracketPattern.exec(text)) !== null) {
+    const parentNum = parseInt(match[1], 10);
+    const childNum = match[2] ? parseInt(match[2], 10) : null;
+    if (!parentNum || parentNum < 1) continue;
+    const { headLine, description } = extractLineContext(text, match.index);
+    // Skip government document number lines (e.g. 【2021】7号)
+    if (isDocumentNumberLine(headLine)) continue;
+    if (!childNum) {
+      raw.push({
+        index: parentNum,
+        id: `section-${parentNum}`,
+        unit: '标的',
+        title: `标的${parentNum}`,
+        headLine,
+        description,
+        matchIndex: match.index,
+        bracketParent: parentNum,
+        bracketChild: null,
+        isBracketGroup: true,
+      });
+    } else {
+      raw.push({
+        index: parentNum * 100 + childNum,
+        id: `section-${parentNum}-${childNum}`,
+        unit: '标段',
+        title: `标段${parentNum}-${childNum}`,
+        headLine,
+        description,
+        matchIndex: match.index,
+        bracketParent: parentNum,
+        bracketChild: childNum,
+        isBracketGroup: false,
+      });
+    }
+  }
+
+  // If we have child sections (X-Y), exclude the parent group headings (X only)
+  const childSections = raw.filter((s) => !s.isBracketGroup);
+  if (childSections.length >= 2) {
+    return childSections;
+  }
+  // If only group headings exist (no children), return them as sections
+  const groupSections = raw.filter((s) => s.isBracketGroup);
+  if (groupSections.length >= 2 && childSections.length === 0) {
+    return groupSections;
+  }
+  // Mixed or single: prefer children
+  return childSections.length >= 2 ? childSections : [];
+}
+
 function detectBidSections(markdown) {
   const text = String(markdown || '');
   if (!text.trim()) {
@@ -132,6 +266,7 @@ function detectBidSections(markdown) {
     return { hasMultiple: false, sections: [], totalDeclared };
   }
 
+  // Detect via explicit section label patterns (e.g. 一标段：, 第1标段：)
   const rawSections = [];
   for (const { pattern, unit } of sectionDefinitionPatterns) {
     pattern.lastIndex = 0;
@@ -140,6 +275,12 @@ function detectBidSections(markdown) {
       const index = normalizeChineseNumber(match[1]);
       if (index && index >= 1) {
         const { headLine, description } = extractLineContext(text, match.index);
+        // Skip combined references like "第一、三标段" where the match
+        // is part of a multi-section mention separated by 、or 、.
+        if (/[一二三四五六七八九十\d]+[、,]\s*[一二三四五六七八九十\d]+\s*(?:标段|标包|分包|包)/.test(headLine)) {
+          match = pattern.exec(text);
+          continue;
+        }
         rawSections.push({
           index,
           id: `section-${index}`,
@@ -154,11 +295,21 @@ function detectBidSections(markdown) {
     }
   }
 
-  if (!rawSections.length) {
+  // Detect via 【X-Y】/【X】 bracket notation (common in 南方电网/国家电网 documents)
+  const bracketSections = detectBracketSections(text);
+  // Merge bracket and pattern results; deduplication handles overlaps.
+  // Bracket child sections (X-Y) are more specific and should take priority
+  // when they cover the same index range as pattern sections.
+  const bracketHasChildren = bracketSections.some((s) => s.unit === '标段');
+  const allSections = bracketHasChildren && bracketSections.length >= rawSections.length
+    ? bracketSections
+    : [...rawSections, ...bracketSections];
+
+  if (!allSections.length) {
     return { hasMultiple: false, sections: [], totalDeclared };
   }
 
-  const deduped = dedupeSections(rawSections);
+  const deduped = dedupeSections(allSections);
   if (deduped.length < 2) {
     return { hasMultiple: false, sections: deduped.map(toSectionOutput), totalDeclared };
   }


### PR DESCRIPTION
## 改动文件
`client/electron/utils/bidSectionDetector.cjs`

## 修复内容

### 1. 支持 4 种标段格式
此前仅支持传统的 `一标段：` 和 `1标段：` 两种格式，现扩展到：

| 格式 | 示例 | 文档来源 |
|------|------|---------|
| 传统中文序数 | `一标段：... 十三标段：...` | 农田建设招标 |
| 南方电网括号 | `【1-1】系统运行专业...` | 贵州电网招标 |
| 数字前缀 | `001 第一标段：天然砂...` | 山西煤炭采购 |
| 表格内嵌 | `标包 1  标包 2  标包 3` | 东莞莞能框架 |

### 2. 其他修复
- **中文数字**: normalizeChineseNumber 支持十一\~九十九，formatChineseNumber 输出 1-99 统一中文
- **分隔符**: `[：:]` 扩展到 `[：:；;]`，兼容分号 `;` 结尾的标段
- **HTML 清理**: 新增 `stripHtml()` 去掉 PDF 转换残留的 `<br>` 和 HTML 标签
- **描述防泄漏**: `extractLineContext` 遇下一标段头自动截断
- **false positive 过滤**: 过滤 `、` 连接的多标段引用、公文编号 `【2021】7号`、TOC 条目、排名表格

### 3. 回归验证
- TypeScript 编译 ✅ `tsc --noEmit`
- Vite 构建 ✅ `vite build`